### PR TITLE
Add a compiler flag for min mac os version 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ message (STATUS "Building ${CMAKE_BUILD_TYPE}")
 set (WARN_FLAGS               "-Wall -Wextra")
 set (CMAKE_CXX_FLAGS          "-std=gnu++11 ${WARN_FLAGS}")
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=10.7")
+endif()
+
 set (CMAKE_CXX_FLAGS_DEBUG    "-g")
 set (CMAKE_CXX_FLAGS_RELEASE  "-O3 -DNDEBUG")
 

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -3,7 +3,7 @@ CC = clang++
 INSTALLDIR = $(PWD)
 
 CPPFLAGS = -D_NO_GUI_ -g -O3 -Weverything -Wno-padded -Wno-c++98-compat -std=c++11 \
-           -Wno-exit-time-destructors -Wno-global-constructors \
+           -mmacosx-version-min=10.5 -Wno-exit-time-destructors -Wno-global-constructors \
            -m64 -pipe
 CPPLIBS = -lpll_optimize -lpll -lm -lpthread
 

--- a/Makefile.console
+++ b/Makefile.console
@@ -3,7 +3,7 @@ CC = g++
 INSTALLDIR = $(PWD)
 
 #CPPFLAGS = -D_NO_GUI_ -g -O3 -Wall -std=c++11 \
-           -m64 -pipe
+           -mmacosx-version-min=10.5 -m64 -pipe
 CPPFLAGS = -D_NO_GUI_ -std=c++11 -g -Wall -O3 -m64 -pipe
 
 CPPLIBS = -lpll_optimize -lpll -lm -lpthread


### PR DESCRIPTION
By adding this compiler flag for a minimum supported MacOS version, the binary get's compiled so that it also runs on older MacOS versions.
Without this PR I compiled the repo and the resulting binary worked on MacOS Catalina, but not on Sierra.
With this PR the compiled binary also worked on MacOS Sierra.
I have not tested other MacOS versions.
