### PR TITLE
Windows installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ different location.
 This will compile pthreads and MPI versions
 Run 'modeltest-ng --help' for help about the console interface.
 
-To compile a Windows executable, install [MSYS2](https://www.msys2.org/) and run:
+## Windows
+
+To compile a Windows executable, install [MSYS2](https://www.msys2.org/), then launch MinGW and run:
 
 ```bash
 $ pacman -S autoconf automake make

--- a/README.md
+++ b/README.md
@@ -131,6 +131,5 @@ $ mkdir build && cd build && cmake .. && make
 $ cd ../../../
 $ autoreconf -i
 $ mkdir build && cd build && cmake .. && make
-$ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run 'modeltest-ng --help' for help about the console interface.
 To compile a Windows executable, install [MSYS2](https://www.msys2.org/), then launch MinGW and run:
 
 ```bash
-$ pacman -S autoconf automake make
+$ pacman -S autoconf automake make gcc
 $ autoreconf -i
 $ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes mingw64-configure
 $ make

--- a/README.md
+++ b/README.md
@@ -114,15 +114,12 @@ different location.
 This will compile pthreads and MPI versions
 Run 'modeltest-ng --help' for help about the console interface.
 
-To compile a Windows executable, install MinGW and run:
+To compile a Windows executable, install [MSYS2](https://www.msys2.org/) and run:
 
 ```bash
+$ pacman -S autoconf automake make
+$ autoreconf -i
 $ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes mingw64-configure
 $ make
 ```
 
-In case the configure script does not exist, it must be generated using autotools:
-
-```bash
-$ autoreconf -i
-```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ different location.
 This will compile pthreads and MPI versions
 Run 'modeltest-ng --help' for help about the console interface.
 
-## Windows
+### Windows installation
 
 To compile a Windows executable, install [MSYS2](https://www.msys2.org/), then launch MinGW and run:
 

--- a/README.md
+++ b/README.md
@@ -119,13 +119,18 @@ Run 'modeltest-ng --help' for help about the console interface.
 To compile a Windows executable, install [MSYS2](https://www.msys2.org/), then launch MinGW and run:
 
 ```bash
-$ pacman -S autoconf automake make gcc libtool flex bison
-$ cd libs/pll-modules
+$ pacman -S autoconf automake make cmake gcc libtool flex bison
+$ cd libs/pll-modules/libs/libpll
 $ autoreconf -i
 $ ./configure
-$ cd ../
-$ autoreconf -i
-$ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes mingw64-configure
 $ make
+$ cd ../../
+$ autoreconf -i
+$ ./configure
+$ mkdir build && cd build && cmake .. && make
+$ cd ../../../
+$ autoreconf -i
+$ mkdir build && cd build && cmake .. && make
+$ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ Run 'modeltest-ng --help' for help about the console interface.
 To compile a Windows executable, install [MSYS2](https://www.msys2.org/), then launch MinGW and run:
 
 ```bash
-$ pacman -S autoconf automake make gcc
+$ pacman -S autoconf automake make gcc libtool flex bison
+$ cd libs/pll-modules
+$ autoreconf -i
+$ ./configure
+$ cd ../
 $ autoreconf -i
 $ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes mingw64-configure
 $ make


### PR DESCRIPTION
I've spent the afternoon trying to compile Windows binaries (cf. #31); the below instructions got me there, after replacing the non-portable function `strcasecmp` with `strcmp` (dangerously..?), per #40 .