### PR TITLE
Add Dockerfile using multi-stage builds process to build modeltest-ng with cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:buster-slim AS builder
+WORKDIR /modeltest
+COPY . /modeltest
+RUN apt update \
+    && apt install -y \
+    autoconf \
+    automake \
+    libtool \
+    bison \
+    flex \
+    cmake \
+    build-essential \
+    git \
+    && mkdir build && cd build \
+    && cmake .. && make
+
+FROM debian:buster-slim
+WORKDIR /root
+COPY --from=builder /modeltest/bin/modeltest-ng /bin
+CMD ["modeltest-ng", "--help"]

--- a/README.md
+++ b/README.md
@@ -126,3 +126,17 @@ In case the configure script does not exist, it must be generated using autotool
 ```bash
 $ autoreconf -i
 ```
+
+3. Using docker
+
+Build docker image using a command like this:
+
+```sh
+docker build -t modeltest-ng .
+```
+
+Then call docker run to create a container using the created image.
+
+```sh
+docker run -it modeltest-ng bash
+```


### PR DESCRIPTION
Hi !
I just want to provide a Dockerfile to bring a new way to use modeltest-ng (without gui) using a docker container.
It's not a very important PR but I think that it can be useful for people who have difficulties to build the project.

Thank you for reading and take care of you.

prx0