### PR TITLE
Use partition length instead of MSA length as sample size

### DIFF
--- a/src/global_defs.h
+++ b/src/global_defs.h
@@ -65,7 +65,7 @@
 #define ERR_MSG_SIZE 240
 
 #define UNUSED(expr) do { (void)(expr); } while (0)
-#define MT_PRECISION_DIGITS 4
+#define MT_PRECISION_DIGITS 17
 
 #define DEFAULT_GAMMA_RATE_CATS   4
 #define DEFAULT_GAMMA_RATE_MODE   PLL_GAMMA_RATES_MEAN

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
         ofstream xml_stream;
         if (ROOT) {
            xml_stream = ofstream(opts.output_results_file + ".xml", std::ios::out);
-           xml_stream << "<modeltestresults>" << endl;
+           xml_stream << "<modeltestresults>" << std::setprecision(17) << endl;
         }
 
         if (ROOT)
@@ -290,9 +290,15 @@ int main(int argc, char *argv[])
               }
 
             xml_stream << "<partition id=\"" <<  i << "\">" << endl;
-            bic_selection->print_xml(xml_stream);
-            aic_selection->print_xml(xml_stream);
-            aicc_selection->print_xml(xml_stream);
+            for (const auto model : ModelTestService::instance()->get_modeltest()->get_models(part_id)) {
+              xml_stream << "<model name=\"" << model->get_name()
+              << "\" lnL=\"" << model->get_loglh()
+              << "\" score-bic=\"" << model->get_bic()
+              << "\" score-aic=\"" << model->get_aic()
+              << "\" score-aicc=\"" << model->get_aicc()
+              << "\" free-params=\"" << model->get_n_free_variables()
+              << "\" />" << endl;
+            }
             xml_stream << "</partition>" << endl;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,6 +180,12 @@ int main(int argc, char *argv[])
 
         ofstream * results_stream = 0;
 
+        ofstream xml_stream;
+        if (ROOT) {
+           xml_stream = ofstream(opts.output_results_file + ".xml", std::ios::out);
+           xml_stream << "<modeltestresults>" << endl;
+        }
+
         if (ROOT)
           results_stream = modeltest::Utils::open_file_for_writing(opts.output_results_file);
 
@@ -283,6 +289,13 @@ int main(int argc, char *argv[])
                                                                   MT_INFO);
               }
 
+            xml_stream << "<partition id=\"" <<  i << "\">" << endl;
+            bic_selection->print_xml(xml_stream);
+            aic_selection->print_xml(xml_stream);
+            aicc_selection->print_xml(xml_stream);
+            xml_stream << "</partition>" << endl;
+
+
               delete bic_selection;
               delete aic_selection;
               delete aicc_selection;
@@ -368,6 +381,14 @@ int main(int argc, char *argv[])
                       << opts.output_tree_file << endl;
           //MT_INFO << "Log written to " << opts.output_log_file << endl;
 
+
+          if (ROOT) {
+            xml_stream << "</modeltestresults>" << endl;
+            xml_stream.close();
+
+            MT_INFO << "Model selections written to " << opts.output_results_file << ".xml." << endl;
+          }
+
           /* clean */
           if (opts.partitions_desc)
               delete opts.partitions_desc;
@@ -399,6 +420,7 @@ int main(int argc, char *argv[])
 BARRIER;
 
     ModelTestService::finalize( false );
+
 
     return return_val;
 }

--- a/src/optimize/model_optimizer_pll.cpp
+++ b/src/optimize/model_optimizer_pll.cpp
@@ -165,7 +165,7 @@ ModelOptimizerPll::ModelOptimizerPll (MsaPll &_msa,
       model.set_loglh(cur_loglh);
       model.set_exec_time(end_time - start_time);
 
-      model.evaluate_criteria(n_branches, msa.get_n_sites());
+      model.evaluate_criteria(n_branches, partition.get_n_sites());
 
       if (optimize_topology)
         model.set_tree(pll_tree);

--- a/src/optimize/model_optimizer_pll.cpp
+++ b/src/optimize/model_optimizer_pll.cpp
@@ -198,6 +198,7 @@ ModelOptimizerPll::ModelOptimizerPll (MsaPll &_msa,
     if (opt_per_param)
     {
       bool all_params_done = false;
+      size_t i = 0;
       while ((fabs (cur_loglh - save_loglh) > epsilon && cur_loglh > save_loglh))
       {
         save_loglh = cur_loglh;
@@ -222,7 +223,10 @@ ModelOptimizerPll::ModelOptimizerPll (MsaPll &_msa,
           opt_delta = cur_loglh;
           notify();
         }
+          ++i;
       }
+
+      LOG_INFO << "\t\t" << model.get_name() << " part " << partition.get_unique_id() << " eps-iteration count: " << i << endl;
     }
     else
     {


### PR DESCRIPTION
It seems the overall MSA length is used as sample size when computing the information criteria. In partitioned analyses, the MSA length does not coincide with the partition length.

Difference in AICc and BIC score can be observed in the following example:

`partitions.txt`:
```
DNA, p1 = 1-400
DNA, p2 = 401-2000
DNA, p3 = 2001-14000
DNA, p4 = 14001-14043
```


`modeltest-ng -i example-data/dna/birds.fas -q partitions.txt`

<details><summary>Without change applied</summary>

    Partition 1/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC              HKY+G4     5153.5607        0.7914
           AIC           TPM3uf+G4     4999.0789        0.1581
          AICc           TPM3uf+G4     4999.0789        0.1581
    
    Partition 2/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC           TIM2+I+G4    17336.8660        0.9997
           AIC           TIM2+I+G4    17163.2188        0.6466
          AICc           TIM2+I+G4    17163.2188        0.6466
    
    Partition 3/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC            GTR+I+G4   143836.0189        0.9590
           AIC            GTR+I+G4   143647.2719        0.9990
          AICc            GTR+I+G4   143647.2719        0.9990
    
    Partition 4/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC              K80+G4      633.6630        0.6091
           AIC             TPM2+G4      502.8833        0.0908
          AICc             TPM2+G4      502.8833        0.0908

</details>

<details><summary>With change applied</summary>

    Partition 1/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC              HKY+G4     5082.3924        0.3576
           AIC           TPM3uf+G4     4999.0789        0.1581
          AICc           TPM3uf+G4     5001.0789        0.1631
    
    Partition 2/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC           TIM2+I+G4    17286.9072        0.9975
           AIC           TIM2+I+G4    17163.2188        0.6466
          AICc           TIM2+I+G4    17163.2188        0.6466
    
    Partition 3/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC            GTR+I+G4   143832.0885        0.9620
           AIC            GTR+I+G4   143647.2719        0.9990
          AICc            GTR+I+G4   143647.2719        0.9990
    
    Partition 4/4:
                             Model         Score        Weight
    ----------------------------------------------------------
           BIC             TPM2+G4      534.5849        0.2349
           AIC             TPM2+G4      502.8833        0.0908
          AICc              K80+G4      529.3150        0.4007

</details>